### PR TITLE
updated cron schedule to run every hour

### DIFF
--- a/management-account-terraform-resources/main.tf
+++ b/management-account-terraform-resources/main.tf
@@ -248,7 +248,7 @@ resource "aws_glue_crawler" "aws_cur_crawler_cost_and_usage_report" {
   role          = aws_iam_role.athena_cost_and_usage_report.arn
   database_name = aws_glue_catalog_database.athenacurcfn_cost_and_usage_report_database.name
   description   = "A recurring crawler that keeps your CUR table in Athena up-to-date."
-  schedule      = "cron(0 0 1 * ? *)" // Run crawler first day of each month at 00:00:00 UTC
+  schedule      = "cron(0 * * * ? *)" // Run crawler every hour. NOTE: previously the crawler ran "on demand", I'm implemeting this hourly run so that the weekly reports wont fail until we can figure out why on demand isn't working with the new design.
 
   s3_target {
     path = "s3://pbmmaccel-master-phase1-cacentral1-${var.mgmt_account_phase1_bucket_suffix}/${data.aws_caller_identity.current.account_id}/cur/Cost-and-Usage-Report/Cost-and-Usage-Report/"


### PR DESCRIPTION
Making this change because running the crawler at the beginning of the month won't work for the weekly reports. I tried switching to "on demand" for the new crawler (the old one that Shea set up is on demand), but couldn't get it to run while just running the reports manually. Until we can figure out what's different I think this is a good compromise. Checked on the cost explorer and I think this should stay under $100/ month for this change. Estimate is ~$70/ month.