### PR TITLE
Enhanced CC functionality to CC additional contacts for the emails sent

### DIFF
--- a/billing-report-utility/helpers.py
+++ b/billing-report-utility/helpers.py
@@ -144,14 +144,16 @@ def send_email(
     msg["From"] = sender
     msg["To"] = recipient
 
+    destinations = [recipient]
     if cc:
+        cc_list = cc.split(',')
+        destinations.extend(cc_list)
         msg["CC"] = cc
 
     if bcc:
+        destinations.append(bcc)
         msg["BCC"] = bcc
 
-    # later we will need to set all destinations. here we quickly make that list
-    destinations = [d for d in [recipient, cc, bcc] if d is not None]
 
     # Set message body
     body = MIMEText(body_text, "html")

--- a/billing-report-utility/summarize_charges.py
+++ b/billing-report-utility/summarize_charges.py
@@ -147,6 +147,9 @@ def enhance_with_metadata(df, accounts):
     df["Owner_Email"] = df["line_item_usage_account_id"].apply(
         lambda x: get_account_metadata(x, "admin_contact_email")
     )
+    df["Additional_Contacts"] = df["line_item_usage_account_id"].apply(
+    lambda x: get_account_metadata(x, "additional_contacts")
+    )
     df["Project"] = df["line_item_usage_account_id"].apply(
         lambda x: get_account_metadata(x, "Project")
     )


### PR DESCRIPTION
- The code, get the emails from additional contact tags and split them based of '/' and adds them as CC's when sending out the emails 
- Note that for quarterly the additional contacts will be empty as we do not want to send quarterly reports to clients
- The code can still accept cc's from env variable. It just appends it to the additional contacts 
- If both RO(RECIPIENT_OVERRIDE) and CC are used, Emails are sent to both